### PR TITLE
Include slug & description in term search

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -15,7 +15,11 @@ const titleSort = (a, b) => a.title > b.title
 /**
  * Find search query in term titles 
  */
-const titleSearch = (search, terms) => terms.filter(term => term.title.toLowerCase().indexOf(search.toLowerCase()) > -1).sort(titleSort)
+const titleSearch = (search, terms) => terms.filter(term => 
+   term.title.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
+   term.description.toLowerCase().indexOf(search.toLowerCase()) > -1 || 
+   term.slug.toLowerCase().indexOf(search.toLowerCase()) > -1
+).sort(titleSort)
 
 export default function Home() {
 


### PR DESCRIPTION
As flagged in #12, I've now included both the slug and description in the site search. 

This will result in a more broad search, E.G. Machine Learning will appear if the term `ai` is searched as that terms appears within the description. 

As the list of terms grows, we could make the search slightly more intelligent and order results by their relevance (title > slug > description). If there are more than X results for a given search term, we expand the search to include the description. Otherwise, we default to just matching the title + slug. 