### PR TITLE
Slug query param fix

### DIFF
--- a/components/Term.js
+++ b/components/Term.js
@@ -67,7 +67,7 @@ export default function Term({ isOpen, title, description, related, onClose, onN
                         </div>
                      </div>
 
-                     <Dialog.Description as="p" className="mt-6 text-xl md:text-2xl text-blue-200">
+                     <Dialog.Description as="div" className="mt-6 text-xl md:text-2xl text-blue-200">
                         <div id="term-content" dangerouslySetInnerHTML={{ __html: description }}></div>
                      </Dialog.Description>
 


### PR DESCRIPTION
Fixed issue #25 preventing query params from loading the correct term into view on page load. 

There was also a semantic warning about a `div` element being within a `p` tag. I've now changed the description parent element to be a `div` now that we're accepting HTML in term descriptions.  