### PR TITLE
Feature/schema

### DIFF
--- a/components/Badge.js
+++ b/components/Badge.js
@@ -1,0 +1,7 @@
+export default function Badge({ children }) {
+   return (
+      <div className="inline-flex bg-black bg-opacity-20 px-2 py-1 rounded text-sm space-x-2">
+         <span className="text-white">{children}</span>
+      </div>
+   )
+}

--- a/components/Term.js
+++ b/components/Term.js
@@ -2,6 +2,7 @@ import { Fragment } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/solid"
 import data from "data/terms.json"
+import Badge from "./Badge"
 
 export default function Term({ isOpen, name, description, acronym, alternateName, related, onClose, onNext, onPrev, onSelectTermSlug }) {
 
@@ -68,19 +69,21 @@ export default function Term({ isOpen, name, description, acronym, alternateName
                      </div>
 
                      <Dialog.Description as="div" className="mt-6 text-xl md:text-2xl text-blue-200">
-                        <div className="flex space-x-2">
-                           {acronym && (
-                              <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
-                                 <span className="text-white">{acronym}</span>
-                              </div>
-                           )}
-                           {alternateName && (
-                              <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
-                                 <span>Also known as: </span>
-                                 <span className="text-white">{alternateName}</span>
-                              </div>
-                           )}
-                        </div>
+                        {(acronym || alternateName) && (
+                           <div className="flex space-x-2 mb-8">
+                              {acronym && (
+                                 <Badge>
+                                    {acronym}
+                                 </Badge>
+                              )}
+                              {alternateName && (
+                                 <Badge>
+                                    <span>Also known as: </span>
+                                    <span className="text-white">{alternateName}</span>
+                                 </Badge>
+                              )}
+                           </div>
+                        )}
                         <div id="term-content" dangerouslySetInnerHTML={{ __html: description }}></div>
                      </Dialog.Description>
 

--- a/components/Term.js
+++ b/components/Term.js
@@ -8,7 +8,7 @@ export default function Term({ isOpen, name, description, related, onClose, onNe
    /**
     * Get related terms from array
     */
-   const relatedTerms = related?.length ? related.map(slug => data.terms.find(term => term.slug === slug)) : []
+   const relatedTerms = related?.length ? related.map(termCode => data.terms.find(term => term.termCode === termCode)) : []
 
    return (
       <Transition appear show={isOpen} as={Fragment}>

--- a/components/Term.js
+++ b/components/Term.js
@@ -3,7 +3,7 @@ import { Dialog, Transition } from "@headlessui/react"
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/solid"
 import data from "data/terms.json"
 
-export default function Term({ isOpen, name, description, acronym, related, onClose, onNext, onPrev, onSelectTermSlug }) {
+export default function Term({ isOpen, name, description, acronym, alternateName, related, onClose, onNext, onPrev, onSelectTermSlug }) {
 
    /**
     * Get related terms from array
@@ -68,12 +68,19 @@ export default function Term({ isOpen, name, description, acronym, related, onCl
                      </div>
 
                      <Dialog.Description as="div" className="mt-6 text-xl md:text-2xl text-blue-200">
-                        {acronym && (
-                           <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
-                              <span>Also known as: </span>
-                              <span className="text-white">{acronym}</span>
-                           </div>
-                        )}
+                        <div className="flex space-x-2">
+                           {acronym && (
+                              <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
+                                 <span className="text-white">{acronym}</span>
+                              </div>
+                           )}
+                           {alternateName && (
+                              <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
+                                 <span>Also known as: </span>
+                                 <span className="text-white">{alternateName}</span>
+                              </div>
+                           )}
+                        </div>
                         <div id="term-content" dangerouslySetInnerHTML={{ __html: description }}></div>
                      </Dialog.Description>
 

--- a/components/Term.js
+++ b/components/Term.js
@@ -3,12 +3,12 @@ import { Dialog, Transition } from "@headlessui/react"
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/solid"
 import data from "data/terms.json"
 
-export default function Term({ isOpen, title, description, related, onClose, onNext, onPrev, onSelectTermSlug }) {
+export default function Term({ isOpen, name, description, related, onClose, onNext, onPrev, onSelectTermSlug }) {
 
    /**
     * Get related terms from array
     */
-   const relatedTerms = related ? data.terms.filter(term => related.includes(term.slug)) : []
+   const relatedTerms = related ? data.terms.filter(term => related.includes(term.termCode)) : []
 
    return (
       <Transition appear show={isOpen} as={Fragment}>
@@ -54,7 +54,7 @@ export default function Term({ isOpen, title, description, related, onClose, onN
                      <div className="flex justify-between space-x-8 items-start">
                         <div>
                            <Dialog.Title as="h2" className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white font-mono">
-                              {title}
+                              {name}
                            </Dialog.Title>
                         </div>
                         <div className="flex items-center">
@@ -78,12 +78,12 @@ export default function Term({ isOpen, title, description, related, onClose, onN
                               <h3 className="text-white font-bold">Related terms</h3>
                               {relatedTerms.map((term, index) => (
                                  <button
-                                    key={term.title}
+                                    key={term.name}
                                     type="button"
-                                    onClick={() => onSelectTermSlug(term.slug)}
+                                    onClick={() => onSelectTermSlug(term.termCode)}
                                     className="block text-blue-200 hover:text-white duration-100"
                                  >
-                                    {term.title}
+                                    {term.name}
                                  </button>
 
                               ))}

--- a/components/Term.js
+++ b/components/Term.js
@@ -3,7 +3,7 @@ import { Dialog, Transition } from "@headlessui/react"
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/solid"
 import data from "data/terms.json"
 
-export default function Term({ isOpen, name, description, related, onClose, onNext, onPrev, onSelectTermSlug }) {
+export default function Term({ isOpen, name, description, acronym, related, onClose, onNext, onPrev, onSelectTermSlug }) {
 
    /**
     * Get related terms from array
@@ -68,6 +68,12 @@ export default function Term({ isOpen, name, description, related, onClose, onNe
                      </div>
 
                      <Dialog.Description as="div" className="mt-6 text-xl md:text-2xl text-blue-200">
+                        {acronym && (
+                           <div className="inline-flex bg-black bg-opacity-20 px-3 py-1 rounded mb-8 text-sm space-x-2">
+                              <span>Also known as: </span>
+                              <span className="text-white">{acronym}</span>
+                           </div>
+                        )}
                         <div id="term-content" dangerouslySetInnerHTML={{ __html: description }}></div>
                      </Dialog.Description>
 

--- a/components/TermList.js
+++ b/components/TermList.js
@@ -18,12 +18,12 @@ export default function TermList({ terms, isShowingTerm, onSelectTermSlug }) {
                {terms.length == 0 && <p className="text-blue-200 hover:text-white text-lg md:text-2xl font-mono duration-100 text-left">No results found.</p>}
                {terms.map((term, index) => (
                   <button
-                     key={term.title + index}
+                     key={term.name + index}
                      type="button"
-                     onClick={() => onSelectTermSlug(term.slug)}
+                     onClick={() => onSelectTermSlug(term.termCode)}
                      className="text-blue-200 hover:text-white text-lg md:text-2xl font-mono duration-100 text-left"
                   >
-                     {term.title}
+                     {term.name}
                   </button>
                ))}
             </div>

--- a/components/TermList.js
+++ b/components/TermList.js
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion"
 import { useState } from "react"
+import Badge from "./Badge"
 
 export default function TermList({ terms, isShowingTerm, onSelectTermSlug }) {
 
@@ -21,9 +22,10 @@ export default function TermList({ terms, isShowingTerm, onSelectTermSlug }) {
                      key={term.name + index}
                      type="button"
                      onClick={() => onSelectTermSlug(term.termCode)}
-                     className="text-blue-200 hover:text-white text-lg md:text-2xl font-mono duration-100 text-left"
+                     className="text-blue-200 hover:text-white text-lg md:text-2xl font-mono duration-100 text-left flex items-center space-x-4"
                   >
-                     {term.name}
+                     <span>{term.name}</span>
+                     {term.acronym && <Badge>{term.acronym}</Badge>}
                   </button>
                ))}
             </div>

--- a/data/terms.json
+++ b/data/terms.json
@@ -1,9 +1,9 @@
 {
   "terms": [
     {
-      "title": "Descriptive analytics",
+      "name": "Descriptive analytics",
       "description": "The analysis of data from the past that can help answer “What happened?” or “What is happening?”.<br><br>For example, an analysis of A&E attendance may show a decrease in visitor numbers over the last 3 months.",
-      "slug": "descriptive-analytics",
+      "termCode": "descriptive-analytics",
       "related": [
         "predictive-analytics",
         "prescriptive-analytics",
@@ -11,9 +11,9 @@
       ]
     },
     {
-      "title": "Predictive analytics",
+      "name": "Predictive analytics",
       "description": "The analysis of data where the goal is to create predictions of the future based on the past that can help answer “What will happen?”<br><br>For example, using historical admissions data, a Trust may be able to predict or forecast the number of admissions in the next 24 hours.",
-      "slug": "predictive-analytics",
+      "termCode": "predictive-analytics",
       "related": [
         "descriptive-analytics",
         "prescriptive-analytics",
@@ -23,9 +23,9 @@
       ]
     },
     {
-      "title": "Prescriptive analytics",
+      "name": "Prescriptive analytics",
       "description": "The use of predictive analytics to recommend or automatically action an activity.<br><br>For example, using a prediction of future admissions, a Trust could recommend or automatically assign a bed to an incoming patient.",
-      "slug": "prescriptive-analytics",
+      "termCode": "prescriptive-analytics",
       "related": [
         "descriptive-analytics",
         "predictive-analytics",
@@ -34,9 +34,9 @@
       ]
     },
     {
-      "title": "Statistics",
+      "name": "Statistics",
       "description": "The process of collecting, classifying and analysing data. Many statistical techniques are used in analytics and modern day machine learning.<br><br>For example, calculating the “average” number of patients arriving at a Trust to inform bed managers of capacity requirements or defining how to optimise the performance of an AI model.",
-      "slug": "statistics",
+      "termCode": "statistics",
       "related": [
         "descriptive-analytics",
         "predictive-analytics",
@@ -47,9 +47,9 @@
       ]
     },
     {
-      "title": "AI",
+      "name": "AI",
       "description": "Artificial Intelligence. The use of digital technology to create systems capable of performing tasks commonly thought to require intelligence.<br><br>For example, an AI system may analyse radiography images and detect tumours in cancer patients.<br><br>In 2021, the UK government announced its <a target='_blank' href='https://www.gov.uk/government/publications/national-ai-strategy'>National AI Strategy</a>.",
-      "slug": "ai",
+      "termCode": "ai",
       "related": [
         "machine-learning",
         "supervised",
@@ -61,9 +61,9 @@
       ]
     },
     {
-      "title": "Algorithm",
+      "name": "Algorithm",
       "description": "A set of instructions that can be followed by a human or computer.<br><br>For example, the NHS <a target='_blank' href='https://www.england.nhs.uk/wp-content/uploads/2014/06/psa-aki-alg.pdf'>algorithm for detecting Acute Kidney Injury</a> is a set of instructions that can be repeated for multiple patients.<br><br>In AI, machine learning algorithms use data to make decisions.",
-      "slug": "algorithm",
+      "termCode": "algorithm",
       "related": [
         "statistics",
         "ai",
@@ -71,9 +71,9 @@
       ]
     },
     {
-      "title": "Data",
+      "name": "Data",
       "description": "Information stored in a digital way.<br><br>For example, this can be information on your physical state such as heart rate, blood pressure, or notes on your recent visit to your primary care physician.<br><br>Imaging data is a common type of healthcare data, which includes data generated from X-ray machines, CT scanners, MRI scanners, OCT systems etc.",
-      "slug": "data",
+      "termCode": "data",
       "related": [
         "structured",
         "unstructured",
@@ -82,9 +82,9 @@
       ]
     },
     {
-      "title": "Model",
+      "name": "Model",
       "description": "A model is a simplified representation of something in the real world. In AI, models are the result of an algorithm and data.<br><br>Models are by definition attempts to define real world phenomena, and can be very helpful when trying to assist in decision making.<br><br>For example, an AI model of bed management may use data on past admissions to predict how many patients will arrive at a point in time, and therefore what the best beds are for these patients taking into account future arrivals.",
-      "slug": "model",
+      "termCode": "model",
       "related": [
         "ai",
         "machine-learning",
@@ -94,9 +94,9 @@
       ]
     },
     {
-      "title": "Machine learning",
+      "name": "Machine learning",
       "description": "An approach to building models using (normally large amounts of) data. This differs from traditional approaches to building models by defining rules by hand.<br><br>For example, a self-driving car will contain many different machine learning algorithms that have been built using data generated by expert drivers.<br><br>AI used in medical imaging leverages machine learning on images with known conditions.",
-      "slug": "machine-learning",
+      "termCode": "machine-learning",
       "related": [
         "ai",
         "supervised",
@@ -110,9 +110,9 @@
       ]
     },
     {
-      "title": "Unsupervised machine learning",
+      "name": "Unsupervised machine learning",
       "description": "A type of machine learning where you do not know the outcome or definition of your data, and are looking for patterns. This includes clustering techniques such as k-nearest neighbours and principal component analysis (PCA).<br><br>For example, unsupervised machine learning can help identify different groups of hospital patients who use hospital services in different ways.",
-      "slug": "unsupervised",
+      "termCode": "unsupervised",
       "related": [
         "supervised",
         "reinforcement",
@@ -123,9 +123,9 @@
       ]
     },
     {
-      "title": "Supervised machine learning",
+      "name": "Supervised machine learning",
       "description": "A type of machine learning where you know the outcome of the data you are looking to model. This includes regression and classification techniques.<br><br>For example, an AI to detect Covid-19 in CT scans can use supervised machine learning with a data set of CT scans where patients have a known outcome (e.g. Covid-19 or not), to predict the likelihood of a new patient having Covid-19 from their CT scan (which the model has not seen before).",
-      "slug": "supervised",
+      "termCode": "supervised",
       "related": [
         "unsupervised",
         "reinforcement",
@@ -137,9 +137,9 @@
       ]
     },
     {
-      "title": "Reinforcement learning",
+      "name": "Reinforcement learning",
       "description": "A type of machine learning where you define an environment and a goal, and iteratively attempt at maximising the goal by reinforcing actions that increase the goal.<br><br>For example, Deepmind successfully used reinforcement learning to master the board game Go by defining the game parameters, the goal and suggesting the best moves to play against real human players.",
-      "slug": "reinforcement",
+      "termCode": "reinforcement",
       "related": [
         "ai",
         "machine-learning",
@@ -148,9 +148,9 @@
       ]
     },
     {
-      "title": "Semi-supervised machine learning",
+      "name": "Semi-supervised machine learning",
       "description": "An approach to machine learning that combines known data (supervised machine learning) with unknown data to improve its ability to act on data it has not seen before.<br><br>This approach is being used to improve models where there is not a lot of data available with a known outcome, for example where you may have a rare disease with less data available than in more common diseases.",
-      "slug": "semi-supervised",
+      "termCode": "semi-supervised",
       "related": [
         "supervised",
         "unsupervised",
@@ -159,9 +159,9 @@
       ]
     },
     {
-      "title": "Self-supervised machine learning",
+      "name": "Self-supervised machine learning",
       "description": "An approach to machine learning where you do not have the outcomes of your data, but use the structure of your data to help determine what these outcomes are.<br><br>For example, recent developments in understanding text and audio can use the existing structure to predict what words should come next.",
-      "slug": "self-supervised",
+      "termCode": "self-supervised",
       "related": [
         "semi-supervised",
         "unsupervised",
@@ -170,18 +170,18 @@
       ]
     },
     {
-      "title": "General AI",
+      "name": "General AI",
       "description": "A theoretical concept of AI that is able to generalise, or adapt, to different applications, much like a human or animal.<br><br>For example, if a human learns to drive a car, they could without too much trouble drive other vehicles.",
-      "slug": "general-ai",
+      "termCode": "general-ai",
       "related": [
         "ai",
         "narrow-ai"
       ]
     },
     {
-      "title": "Narrow AI",
+      "name": "Narrow AI",
       "description": "AI focussed on solving a specific problem.<br><br>For example, an AI built to identify cancerous tumours in breast scans, would not automatically be able to detect tumours in other parts of the body without significant rework.",
-      "slug": "narrow-ai",
+      "termCode": "narrow-ai",
       "related": [
         "ai",
         "general-ai",
@@ -191,36 +191,36 @@
       ]
     },
     {
-      "title": "MLOps",
+      "name": "MLOps",
       "description": "Machine learning operations is the process of safely deploying, monitoring and updating machine learning models in production, or real-world, environments.<br><br>Because machine learning models are built on data, and data can change, it is important to build robustness into the system so they can adapt to a changing environment without losing performance.",
-      "slug": "mlops",
+      "termCode": "mlops",
       "related": [
         "machine-learning",
         "model"
       ]
     },
     {
-      "title": "Cloud",
+      "name": "Cloud",
       "description": "An approach to computing where resources are no longer on premise, but hosted in different locations managed by a third-party.<br><Br>For example, a hospital may store patient records on computers physically housed within the hospital, which require maintenance. By moving to the cloud (a marketplace of cloud vendors is established), the hospital can outsource the maintenance and expenditure of physically owning the computers, in return for renting space.<br><br>In 2013 the UK government released its “<a target='_blank' href='https://www.gov.uk/guidance/government-cloud-first-policy'>Cloud First policy</a>”.",
-      "slug": "cloud",
+      "termCode": "cloud",
       "related": [
         "on-prem",
         "database"
       ]
     },
     {
-      "title": "On-premise",
+      "name": "On-premise",
       "description": "An approach to computing where you physically locate your equipment on your premise. For example, a hospital which stores your records within the hospital buildings or nearby in hospital-owned buildings.",
-      "slug": "on-prem",
+      "termCode": "on-prem",
       "related": [
         "database",
         "cloud"
       ]
     },
     {
-      "title": "Hybrid cloud",
+      "name": "Hybrid cloud",
       "description": "An approach to working with both cloud and on-premise computing resources, where some resources can be on-premise (e.g. data), and other resources can be in the Cloud (e.g. applications that use the data). With a secure connection between the premise and the Cloud you can implement a hybrid cloud.",
-      "slug": "hybrid",
+      "termCode": "hybrid",
       "related": [
         "cloud",
         "on-prem",
@@ -228,25 +228,25 @@
       ]
     },
     {
-      "title": "Python",
+      "name": "Python",
       "description": "A general purpose computer programming language that has become very popular for data science, machine learning and AI. It is free to learn and has a large community of developers who contribute additional features.<br><br>There is a thriving <a target='_blank' href='https://nhs-pycom.net/'>NHS Python Community for Healthcare</a>.",
-      "slug": "python",
+      "termCode": "python",
       "related": [
         "R"
       ]
     },
     {
-      "title": "R",
+      "name": "R",
       "description": "A statistical computer programming language that is commonly used for data analysis and data science. R is free to learn and has a large community of developers who contribute additional features.<br><br>There is a thriving <a target='_blank' href='https://nhsrcommunity.com/'>NHS-R Community</a>.",
-      "slug": "R",
+      "termCode": "R",
       "related": [
         "python"
       ]
     },
     {
-      "title": "API",
+      "name": "API",
       "description": "Application Programming Interface. A standardised way to share data. An API defines the mechanisms to receive and send data, which is agnostic to how the underlying data is stored.<br><br>For example, NHS Digital has a <a target='_blank' href='https://digital.nhs.uk/developer/api-catalogue'>number of APIs</a> available to help build modern healthcare technology.",
-      "slug": "api",
+      "termCode": "api",
       "related": [
         "database",
         "cloud",
@@ -255,44 +255,44 @@
       ]
     },
     {
-      "title": "Standard",
+      "name": "Standard",
       "description": "An agreed set of definitions, guidelines and sometimes technical approaches for a specific area. Formal Standards may be mandated by the Government, whereas de facto standards are created and used by communities working in that space.<br><br>For example, ISO 13485 is a UK <a target='_blank' href='https://www.gov.uk/guidance/designated-standards#healthcare-engineering'>Designated Standard</a> for quality management systems for medical device, it can be used to <a target='_blank' href='https://www.gov.uk/guidance/medical-devices-conformity-assessment-and-the-ukca-mark#compliance-with-designated-standards'>demonstrate conformance</a> with parts of the medical device regulations.",
-      "slug": "standard",
+      "termCode": "standard",
       "related": [
         "interoperability"
       ]
     },
     {
-      "title": "Pseudonymisation",
+      "name": "Pseudonymisation",
       "description": "A technique that separates data from direct identifiers (for example name, surname, NHS number) and replaces them with a pseudonym (for example, a reference number), so that identifying an individual from that data is not possible without additional information. The organisation that conducted pseudonymisation will be able to re-identify individuals if required.",
-      "slug": "pseudonymisation",
+      "termCode": "pseudonymisation",
       "related": [
         "data-protection",
         "anonymisation"
       ]
     },
     {
-      "title": "Anonymisation",
+      "name": "Anonymisation",
       "description": "The process of removing all identifiable information from data in a way which makes it theoretically infeasible to identify an individual.  Anonymised data is not considered as personal data under the GDPR. This means it is not subject to the same restrictions as personal data.<br><br>For example, by removing direct identifiers such as NHS number and name, and translating e.g. age into an age range (25-40) and grouping postcodes together.<br><br>You can read more about the challenges and approaches to anonymisation in the <a target='_blank' href='https://ico.org.uk/media/1061/anonymisation-code.pdf'>ICO code of practice</a>.",
-      "slug": "anonymisation",
+      "termCode": "anonymisation",
       "related": [
         "pseudonymisation",
         "data-protection"
       ]
     },
     {
-      "title": "Data protection",
+      "name": "Data protection",
       "description": "The principles, legislation and processes to ensure that individuals can trust an organisation to use their data fairly and safely.<br><br>There are three key pieces of legislation that protect the collection, sharing and processing of data within the health and care system: Common Law Duty of Confidentiality, the General Data Protection Regulation (GDPR) and the Data Protection Act 2018 (DPR).",
-      "slug": "data-protection",
+      "termCode": "data-protection",
       "related": [
         "anonymisation",
         "pseudonymisation"
       ]
     },
     {
-      "title": "EHR",
+      "name": "EHR",
       "description": "“Electronic health record”, also known as electronic patient record (EPR) or electronic medical record (EMR), contains the personal health records of an individual in digital format, such as visits to primary and secondary care, prescriptions, diagnoses and clinical notes.",
-      "slug": "ehr",
+      "termCode": "ehr",
       "related": [
         "database",
         "cloud",
@@ -301,9 +301,9 @@
       ]
     },
     {
-      "title": "Database",
+      "name": "Database",
       "description": "A collection of information or data stored and managed electronically. There are many different types of database depending on the data stored e.g. image data, text data or numerical data.<br><br>For example, your local Trust will manage a database containing your electronic health records (EHR). This database and the software that manages it may be referred to as an EHR system.",
-      "slug": "database",
+      "termCode": "database",
       "related": [
         "data",
         "structured",
@@ -313,9 +313,9 @@
       ]
     },
     {
-      "title": "Structured data",
+      "name": "Structured data",
       "description": "Information which is well structured, such as a spreadsheet of information. This means there are defined columns and you can expect additional data to follow the same or similar structure (perhaps with some missing values).<br><br>Historically, data analysis was limited to structured data as it is well defined. More recently, advances in AI mean unstructured data is now more accessible.",
-      "slug": "structured",
+      "termCode": "structured",
       "related": [
         "data",
         "unstructured",
@@ -323,9 +323,9 @@
       ]
     },
     {
-      "title": "Unstructured data",
+      "name": "Unstructured data",
       "description": "Information which may have some structure (e.g. a name or some simple attributes or metadata), but by definition could contain a range of information.<br><br>For example, images contain some structured data (image size, image format, image name) but the contents of those images can vary completely. Audio also contains some structure (length, format) but can vary considerably.<br><br>Recent developments in approaches to AI, computational power and quantity of data have led to an increase in AI in unstructured data, such as medical imaging and speech to text.",
-      "slug": "unstructured",
+      "termCode": "unstructured",
       "related": [
         "data",
         "structured",
@@ -333,9 +333,9 @@
       ]
     },
     {
-      "title": "Explainability",
+      "name": "Explainability",
       "description": "AI can be built on complex algorithms and data, and explainability is a measure of how understandable, or explainable, the decisions of an AI system are to humans.<br><br>For example, an AI may predict which patients are most in need of surgery, but should be able to explain why it has prioritised patients in a certain way.",
-      "slug": "explainability",
+      "termCode": "explainability",
       "related": [
         "ai",
         "fairness",
@@ -346,9 +346,9 @@
       ]
     },
     {
-      "title": "Local explainability",
+      "name": "Local explainability",
       "description": "The ability to explain why an AI prediction has been made for a specific data point.<br><br>For example, an AI predicts that you should attend a follow-up appointment in 6 months, and is able to share what factors led to this specific, individual, decision (e.g. date of your last appointment, pre-existing conditions).",
-      "slug": "local-explainability",
+      "termCode": "local-explainability",
       "related": [
         "explainability",
         "ai",
@@ -358,9 +358,9 @@
       ]
     },
     {
-      "title": "General explainability",
+      "name": "General explainability",
       "description": "Sometimes referred to as global explainability, general explainability is an approach to sharing what features or data points had the most influence over an AI model's predictions.<br><br>For example, in an AI system for predicting length of stay in hospital, age and location were the two most important factors.",
-      "slug": "general-explainability",
+      "termCode": "general-explainability",
       "related": [
         "explainability",
         "ai",
@@ -370,9 +370,9 @@
       ]
     },
     {
-      "title": "Inference",
+      "name": "Inference",
       "description": "In AI, inference is the process of making a prediction from a model that has already been trained.<br><br>For example, a hospital may implement a new AI model that can suggest the best bed allocation for an incoming patient. Inference occurs when that new patient arrives, and the system is run to suggest a new allocation.",
-      "slug": "inference",
+      "termCode": "inference",
       "related": [
         "ai",
         "machine-learning",
@@ -381,9 +381,9 @@
       ]
     },
     {
-      "title": "Training",
+      "name": "Training",
       "description": "Most types of AI require a training process, which uses historical data to build a model able to predict future cases.<br><br>For example, researchers have trained models to predict Covid-19 from patient X-rays using the NCCID database.",
-      "slug": "training",
+      "termCode": "training",
       "related": [
         "machine-learning",
         "supervised",
@@ -395,43 +395,43 @@
       ]
     },
     {
-      "title": "Causality",
+      "name": "Causality",
       "description": "The influence of an event resulting, or causing, another.<br><br>For example, consuming more calories than you use up will lead to weight gain.<br><br>While many AI systems use patterns found in data to make predictions, very rarely are these patterns sufficient to determine the underlying cause of a behaviour.",
-      "slug": "causality",
+      "termCode": "causality",
       "related": [
         "correlation",
         "explainability"
       ]
     },
     {
-      "title": "Correlation",
+      "name": "Correlation",
       "description": "A measure that expresses the extent to which data are related in a direct, or linear, way. It describes a relationship between data without making any statement about cause and effect (i.e. correlation does not mean causality). However, it can describe a positive or negative, also known as inverse, relationship between these data. Positive would be if one goes up the other goes up too, negative would be if one if one goes up the other one goes down.<br><br>For example, an individual's weight is correlated to their height and waiting times are correlated to the number of people waiting.",
-      "slug": "correlation",
+      "termCode": "correlation",
       "related": [
         "causality",
         "unsupervised"
       ]
     },
     {
-      "title": "Ecological fallacy",
+      "name": "Ecological fallacy",
       "description": "It occurs when attributing characteristics of a group to an individual part of that group. In other words, you should not make conclusions about individuals based on findings about the group they belong to.",
-      "slug": "ecological-fallacy",
+      "termCode": "ecological-fallacy",
       "related": [
         "explainability"
       ]
     },
     {
-      "title": "Clinical trials",
+      "name": "Clinical trials",
       "description": "A formal experiment used to scientifically evaluate the performance of a medicine, technology or process before being approved for widespread use.<br><br>For example, many medicines will undertake a series of trials to demonstrate their effectiveness and safety.<br><br>You can find out more about clinical trials in the UK at the <a target='_blank' href='https://www.nhs.uk/conditions/clinical-trials/'>NHS website</a>.",
-      "slug": "clinical-trials",
+      "termCode": "clinical-trials",
       "related": [
         "test-data"
       ]
     },
     {
-      "title": "Fairness",
+      "name": "Fairness",
       "description": "When individuals are not penalised by algorithms because they are part of a (sensitive) group.<br><br>For example, an AI algorithm used in law enforcement in the USA was shown to unfairly increase sentence recommendations based on racial background.",
-      "slug": "fairness",
+      "termCode": "fairness",
       "related": [
         "bias",
         "explainability",
@@ -441,9 +441,9 @@
       ]
     },
     {
-      "title": "Bias",
+      "name": "Bias",
       "description": "Errors contained in AI which unfairly treat a group of individuals over another.<br><br>AI algorithms are often trained on historical data which can contain bias that exists in society. Unless the algorithms are built with fairness in mind, they may repeat this bias in their predictions.<br><br>For example, an AI trained on CVs from engineers, who are historically predominantly male, may unfairly penalise CVs from women if the algorithms are not tested for fairness and modified to remove bias.",
-      "slug": "bias",
+      "termCode": "bias",
       "related": [
         "fairness",
         "explainability",
@@ -453,25 +453,25 @@
       ]
     },
     {
-      "title": "PoC",
+      "name": "PoC",
       "description": "Proof of concept. A demonstration of the feasibility, or possibility, of a technology to be able to perform a task or solve a specific problem. A PoC is an early stage exploration, and would be followed by additional testing and engineering to ensure its viability in a real world setting.<br><br>For example, the <a target='_blank' href='https://www.nhsx.nhs.uk/ai-lab/ai-lab-programmes/skunkworks/'>NHS AI Lab Skunkworks</a> team publishes PoCs on a range of problems, such as using AI to allocate beds or predict length of stay in hospital.",
-      "slug": "poc",
+      "termCode": "poc",
       "related": [
         "trl"
       ]
     },
     {
-      "title": "TRL",
+      "name": "TRL",
       "description": "Technology readiness level. A <a target='_blank' href='https://en.wikipedia.org/wiki/Technology_readiness_level'>framework</a> developed by NASA to describe the different levels of maturity of a technology.<br><br>For example, a proof of concept may come under TRL level 4.<br><br>TRL levels start at 1 for a basic idea through to 9 for a fully deployed solution.",
-      "slug": "trl",
+      "termCode": "trl",
       "related": [
         "poc"
       ]
     },
     {
-      "title": "Training data",
+      "name": "Training data",
       "description": "The data required to train, or “teach” a machine learning algorithm when developing a model.<br><br>Good quality training data that is reflective of the population, unbiased and large enough to ensure a robust model is a key prerequisite for AI.",
-      "slug": "training-data",
+      "termCode": "training-data",
       "related": [
         "test-data",
         "validation-data",
@@ -483,9 +483,9 @@
       ]
     },
     {
-      "title": "Test data",
+      "name": "Test data",
       "description": "Data that is not included in the training data, and used to test that a model has accurately identified the patterns in the data that result in the desired behaviour.<br><br>For example, the NCCID holds an external validation data set used to test commercial and academic models built to detect Covid-19 from chest X-rays and CT scans.",
-      "slug": "test-data",
+      "termCode": "test-data",
       "related": [
         "validation-data",
         "training-data",
@@ -496,9 +496,9 @@
       ]
     },
     {
-      "title": "Cross validation",
+      "name": "Cross validation",
       "description": "An approach to reducing overfitting during model development, by iteratively selecting different portions of the data to train and validate a predictive (supervised) machine learning model.<br><br>Cross validation can increase the overall performance of a model, along with data augmentation techniques.",
-      "slug": "cross-validation",
+      "termCode": "cross-validation",
       "related": [
         "training-data",
         "validation-data",
@@ -511,9 +511,9 @@
       ]
     },
     {
-      "title": "Validation data",
+      "name": "Validation data",
       "description": "Data that is not included in the training data, but is used to check the performance of the model as it is being trained. This is separate to the test data used to check the final performance of the model.<br><br>This definition relates to the definition within AI, and not the regulatory aspects of medical devices.",
-      "slug": "validation-data",
+      "termCode": "validation-data",
       "related": [
         "test-data",
         "training-data",
@@ -524,9 +524,9 @@
       ]
     },
     {
-      "title": "Classification",
+      "name": "Classification",
       "description": "A type of machine learning model which can predict whether or not you belong to a specific class, or group. Common approaches include logistic regression, decision trees and random forests.<br><br>For example, a classification model may be built to identify individuals with  diabetes. The classes could be Type-I diabetes, Type-II diabetes, gestational diabetes or no diabetes. Normally, a model would return the probability that you belonged to each class, and would assign you to the class with the highest probability.",
-      "slug": "classification",
+      "termCode": "classification",
       "related": [
         "supervised",
         "ai",
@@ -536,9 +536,9 @@
       ]
     },
     {
-      "title": "Regression",
+      "name": "Regression",
       "description": "A type of machine learning model that predicts a continuous value, instead of a discrete value as is the case in classification models.<br><br>For example, a regression model may predict how long you will stay in a hospital bed upon admission. This value will be a numerical value e.g. 27 hours, or 28 hours.",
-      "slug": "regression",
+      "termCode": "regression",
       "related": [
         "supervised",
         "ai",
@@ -548,9 +548,9 @@
       ]
     },
     {
-      "title": "Accuracy",
+      "name": "Accuracy",
       "description": "The proportion of correctly identified positive and negative cases in a classification model.<br><br>For example, an AI model that correctly identifies all positive and negative cases of patients with e.g. Covid-19 would have an accuracy of 1.0 (100%).",
-      "slug": "accuracy",
+      "termCode": "accuracy",
       "related": [
         "specificity",
         "sensitivity",
@@ -566,9 +566,9 @@
       ]
     },
     {
-      "title": "Specificity",
+      "name": "Specificity",
       "description": "The ability of a classification model to correctly identify individuals <em>without</em> a condition. This is also known as the true negative rate.<br><br>For example, an AI tool that has been developed to detect lung cancer from medical images is said to be specific if it correctly identifies people who do not have lung cancer.",
-      "slug": "specificity",
+      "termCode": "specificity",
       "related": [
         "accuracy",
         "sensitivity",
@@ -584,9 +584,9 @@
       ]
     },
     {
-      "title": "Sensitivity",
+      "name": "Sensitivity",
       "description": "The ability of a classification model to correctly identify individuals <em>with</em> a condition. This is also known as the true positive rate and recall. It is defined as the number of true positives over true positives and false negatives.<br><br>For example, an AI tool that has been developed to detect lung cancer from medical images is said to be sensitive if it correctly identifies people who have lung cancer.",
-      "slug": "sensitivity",
+      "termCode": "sensitivity",
       "related": [
         "accuracy",
         "specificity",
@@ -602,9 +602,9 @@
       ]
     },
     {
-      "title": "False positive",
+      "name": "False positive",
       "description": "The incorrect prediction of a data point or individual having a specific outcome or class.<br><br>For example, if an AI tool incorrectly predicts you have diabetes.",
-      "slug": "false-positive",
+      "termCode": "false-positive",
       "related": [
         "accuracy",
         "specificity",
@@ -620,9 +620,9 @@
       ]
     },
     {
-      "title": "False negative",
+      "name": "False negative",
       "description": "The incorrect prediction of a data point or individual not having a specific outcome or class.<br><br>For example, if an AI tool incorrectly predicts you do not have diabetes, when in fact, you do.",
-      "slug": "false-negative",
+      "termCode": "false-negative",
       "related": [
         "accuracy",
         "specificity",
@@ -638,9 +638,9 @@
       ]
     },
     {
-      "title": "True positive",
+      "name": "True positive",
       "description": "The correct prediction of a data point or individual having a specific outcome or class.<br><br>For example, if an AI tool correctly predicts you have diabetes.",
-      "slug": "true-positive",
+      "termCode": "true-positive",
       "related": [
         "accuracy",
         "specificity",
@@ -656,9 +656,9 @@
       ]
     },
     {
-      "title": "True negative",
+      "name": "True negative",
       "description": "The correct prediction of a data point or individual not having a specific outcome or class.<br><br>For example, if an AI tool correctly predicts you do not have diabetes.",
-      "slug": "true-negative",
+      "termCode": "true-negative",
       "related": [
         "accuracy",
         "specificity",
@@ -674,9 +674,9 @@
       ]
     },
     {
-      "title": "Precision",
+      "name": "Precision",
       "description": "A way of measuring how effective a classification model is at detecting positive cases. It is the ratio of true positives over all positive cases (true and false positives).<br><br>For example, a model with high precision (1.0) will correctly identify all positive cases. Note this does not account for false negatives, and a high precision could be obtained by assigning every case as a positive case.",
-      "slug": "precision",
+      "termCode": "precision",
       "related": [
         "accuracy",
         "specificity",
@@ -692,9 +692,9 @@
       ]
     },
     {
-      "title": "Operating point",
+      "name": "Operating point",
       "description": "In a classification model, this is the point chosen to define when a case is positive or not. The location of this point will determine the model performance measured by true positives, false positives, true negatives and false negatives.<br><br>For an interactive demonstration on the impact on deciding the operating point, visit this <a target='_blank' href='https://nhsx.github.io/covid-chest-imaging-database/experiments'>NCCID operating point experiment</a>.",
-      "slug": "operating-point",
+      "termCode": "operating-point",
       "related": [
         "accuracy",
         "specificity",
@@ -710,9 +710,9 @@
       ]
     },
     {
-      "title": "ROC",
+      "name": "ROC",
       "description": "Receiver Operator Characteristic. Used to create a plotted curve which demonstrates how the trade off between true positive rate and false positive rate changes as you vary the operating point of a classification model.<br><br>For an interactive demonstration of a ROC curve, visit this <a target='_blank' href='https://nhsx.github.io/covid-chest-imaging-database/experiments'>NCCID operating point experiment</a>.",
-      "slug": "roc",
+      "termCode": "roc",
       "related": [
         "accuracy",
         "specificity",
@@ -728,9 +728,9 @@
       ]
     },
     {
-      "title": "AUC",
+      "name": "AUC",
       "description": "Area Under the (Receiver Operator Character) Curve. A single number calculated from a ROC curve to help summarise the performance of a classification model.",
-      "slug": "auc",
+      "termCode": "auc",
       "related": [
         "accuracy",
         "specificity",
@@ -746,9 +746,9 @@
       ]
     },
     {
-      "title": "F1 score",
+      "name": "F1 score",
       "description": "A metric which describes the accuracy of a classification model, by combining the precision and sensitivity (recall) values into a single number, which ranges from 0 (poor accuracy) to 1 (high accuracy).",
-      "slug": "f1-score",
+      "termCode": "f1-score",
       "related": [
         "precision",
         "sensitivity",
@@ -760,26 +760,26 @@
       ]
     },
     {
-      "title": "NCCID",
+      "name": "NCCID",
       "description": "National COVID-19 Chest Imaging Database. The NCCID is a national database that supports better understanding of COVID-19 and the development of technology enabling the best care for patients hospitalised with a severe infection.",
-      "slug": "nccid",
+      "termCode": "nccid",
       "related": [
         "database"
       ]
     },
     {
-      "title": "Interoperability",
+      "name": "Interoperability",
       "description": "The ability of digital systems to exchange information without requiring significant efforts to convert data from different formats. AI is built on data, and accessing data from different systems requires a level of standardisation and interoperability to ensure a robust model can be built and used.",
-      "slug": "interoperability",
+      "termCode": "interoperability",
       "related": [
         "standard",
         "api"
       ]
     },
     {
-      "title": "Multimodal AI",
+      "name": "Multimodal AI",
       "description": "An approach to AI which incorporates multiple types of data. For example, a speech-to-text model that is typically trained on audio and text data, could include image data of lip movements taken from video recordings.<br><br>Multimodal AI can combine both numerical data such as blood pressure, heart rate, and imaging data such as a CT scan.<br><br>In healthcare, the term is also associated with specific 'modalities' of data, such as the sequences in <a target='_blank' href='https://prostatecanceruk.org/about-us/projects-and-policies/mpmri'>mpMRI</a> scanning. However, the concept of multimodality with respect to AI is more than just bringing different types of data together - it is about how very different AI models effectively interoperate - even 'merge' - to create a whole that is greater than the sum of its parts.",
-      "slug": "multimodal",
+      "termCode": "multimodal",
       "related": [
         "model",
         "machine-learning",
@@ -787,9 +787,9 @@
       ]
     },
     {
-      "title": "Neural network",
+      "name": "Neural network",
       "description": "Neural networks are an approach to machine learning, loosely inspired by nature, that can describe complex relationships using a broader range of data than traditional approaches.<br><br>For example, neural networks can be trained on image data to describe features in medical images such as tumours. They can also be trained on free text such as clinical notes, allowing their use in clinical coding applications.<br><br>Neural networks can also be trained on tabulated, or structured data, such as a spreadsheet. Their ability to model complexity often comes at the cost of explainability, whereby the more complex the model, the harder to explain it becomes.",
-      "slug": "neural-network",
+      "termCode": "neural-network",
       "related": [
         "model",
         "machine-learning",
@@ -801,9 +801,9 @@
       ]
     },
     {
-      "title": "Deep learning",
+      "name": "Deep learning",
       "description": "An approach to building models using neural networks with more than one 'hidden' layer of artificial neurons. This is a common approach when working with image and text data.<br><br>Deep learning models are able to capture complex relationships but can be difficult to interpret what data leads to a particular outcome.",
-      "slug": "deep-learning",
+      "termCode": "deep-learning",
       "related": [
         "neural-network",
         "machine-learning",
@@ -814,9 +814,9 @@
       ]
     },
     {
-      "title": "Overfitting",
+      "name": "Overfitting",
       "description": "The process of building a model which is based too closely on the data. This results in a model which may be very accurate on the training data, but when tested on additional datasets such as the test data, unseen data or data from a new environment, performs badly.<br><br>Approaches to reduce overfitting include cross-validation, data augmentation and ensemble techniques (which combine different models).",
-      "slug": "overfitting",
+      "termCode": "overfitting",
       "related": [
         "underfitting",
         "machine-learning",
@@ -829,9 +829,9 @@
       ]
     },
     {
-      "title": "Underfitting",
+      "name": "Underfitting",
       "description": "The process of building a model which is not based closely enough on the data. This results in a model which performs badly and fails to capture the relationships you are looking for.<br><br>There is a balance to be made between underfitting and overfitting.",
-      "slug": "underfitting",
+      "termCode": "underfitting",
       "related": [
         "overfitting",
         "machine-learning",
@@ -840,9 +840,9 @@
       ]
     },
     {
-      "title": "Data augmentation",
+      "name": "Data augmentation",
       "description": "The process of artificially increasing the amount of data used to train a model, to reduce overfitting and improve model performance.<br><br>Commonly used in imaging applications, this can include rotating, cropping, adding noise or random levels of blur to existing images.",
-      "slug": "data-augmentation",
+      "termCode": "data-augmentation",
       "related": [
         "overfitting",
         "training",
@@ -851,9 +851,9 @@
       ]
     },
     {
-      "title": "NLP",
+      "name": "NLP",
       "description": "Natural language processing. A collection of techniques which use speech and text data.<br><br>Speech-to-text systems convert verbal speech to text, such as in a smart speaker.<br>Natural language understanding systems convert text into concepts or instructions, such as your requests to play music or offer directions.<br>Text-to-speech systems convert text into verbal speech, such as responses from a smart speaker.<br>Natural language generation will create human-like text based on concepts, such as writing a report from a summary table of data.<br><br>NLP has developed significantly in recent years in part due to the availability of deep learning algorithms and transfomers.",
-      "slug": "nlp",
+      "termCode": "nlp",
       "related": [
         "deep-learning",
         "transformer",
@@ -864,9 +864,9 @@
       ]
     },
     {
-      "title": "Transformer",
+      "name": "Transformer",
       "description": "An approach to deep learning which uses an 'attention' mechanism to understand context in text or image data, without requiring data to be processed in order.<br><br>Transformers have led to recent breakthroughs in NLP and computer vision.",
-      "slug": "transformer",
+      "termCode": "transformer",
       "related": [
         "nlp",
         "deep-learning",

--- a/data/terms.json
+++ b/data/terms.json
@@ -47,8 +47,9 @@
       ]
     },
     {
-      "name": "AI",
-      "description": "Artificial Intelligence. The use of digital technology to create systems capable of performing tasks commonly thought to require intelligence.<br><br>For example, an AI system may analyse radiography images and detect tumours in cancer patients.<br><br>In 2021, the UK government announced its <a target='_blank' href='https://www.gov.uk/government/publications/national-ai-strategy'>National AI Strategy</a>.",
+      "name": "Artificial Intelligence",
+      "acronym": "AI",
+      "description": "The use of digital technology to create systems capable of performing tasks commonly thought to require intelligence.<br><br>For example, an AI system may analyse radiography images and detect tumours in cancer patients.<br><br>In 2021, the UK government announced its <a target='_blank' href='https://www.gov.uk/government/publications/national-ai-strategy'>National AI Strategy</a>.",
       "termCode": "ai",
       "related": [
         "machine-learning",
@@ -170,7 +171,8 @@
       ]
     },
     {
-      "name": "General AI",
+      "name": "General artificial intelligence",
+      "acronym": "General AI",
       "description": "A theoretical concept of AI that is able to generalise, or adapt, to different applications, much like a human or animal.<br><br>For example, if a human learns to drive a car, they could without too much trouble drive other vehicles.",
       "termCode": "general-ai",
       "related": [
@@ -179,7 +181,8 @@
       ]
     },
     {
-      "name": "Narrow AI",
+      "name": "Narrow artificial intelligence",
+      "acronym": "Narrow AI",
       "description": "AI focussed on solving a specific problem.<br><br>For example, an AI built to identify cancerous tumours in breast scans, would not automatically be able to detect tumours in other parts of the body without significant rework.",
       "termCode": "narrow-ai",
       "related": [
@@ -191,8 +194,9 @@
       ]
     },
     {
-      "name": "MLOps",
-      "description": "Machine learning operations is the process of safely deploying, monitoring and updating machine learning models in production, or real-world, environments.<br><br>Because machine learning models are built on data, and data can change, it is important to build robustness into the system so they can adapt to a changing environment without losing performance.",
+      "name": "Machine learning operations",
+      "acronym": "MLOps",
+      "description": "The process of safely deploying, monitoring and updating machine learning models in production, or real-world, environments.<br><br>Because machine learning models are built on data, and data can change, it is important to build robustness into the system so they can adapt to a changing environment without losing performance.",
       "termCode": "mlops",
       "related": [
         "machine-learning",
@@ -244,8 +248,9 @@
       ]
     },
     {
-      "name": "API",
-      "description": "Application Programming Interface. A standardised way to share data. An API defines the mechanisms to receive and send data, which is agnostic to how the underlying data is stored.<br><br>For example, NHS Digital has a <a target='_blank' href='https://digital.nhs.uk/developer/api-catalogue'>number of APIs</a> available to help build modern healthcare technology.",
+      "name": "Application programming interface",
+      "acronym": "API",
+      "description": "A standardised way to share data. An API defines the mechanisms to receive and send data, which is agnostic to how the underlying data is stored.<br><br>For example, NHS Digital has a <a target='_blank' href='https://digital.nhs.uk/developer/api-catalogue'>number of APIs</a> available to help build modern healthcare technology.",
       "termCode": "api",
       "related": [
         "database",
@@ -290,8 +295,9 @@
       ]
     },
     {
-      "name": "EHR",
-      "description": "“Electronic health record”, also known as electronic patient record (EPR) or electronic medical record (EMR), contains the personal health records of an individual in digital format, such as visits to primary and secondary care, prescriptions, diagnoses and clinical notes.",
+      "name": "Electronic health record",
+      "acronym": "EHR",
+      "description": "Also known as electronic patient record (EPR) or electronic medical record (EMR), contains the personal health records of an individual in digital format, such as visits to primary and secondary care, prescriptions, diagnoses and clinical notes.",
       "termCode": "ehr",
       "related": [
         "database",
@@ -453,16 +459,18 @@
       ]
     },
     {
-      "name": "PoC",
-      "description": "Proof of concept. A demonstration of the feasibility, or possibility, of a technology to be able to perform a task or solve a specific problem. A PoC is an early stage exploration, and would be followed by additional testing and engineering to ensure its viability in a real world setting.<br><br>For example, the <a target='_blank' href='https://www.nhsx.nhs.uk/ai-lab/ai-lab-programmes/skunkworks/'>NHS AI Lab Skunkworks</a> team publishes PoCs on a range of problems, such as using AI to allocate beds or predict length of stay in hospital.",
+      "name": "Proof of concept",
+      "acronym": "PoC",
+      "description": "A demonstration of the feasibility, or possibility, of a technology to be able to perform a task or solve a specific problem. A PoC is an early stage exploration, and would be followed by additional testing and engineering to ensure its viability in a real world setting.<br><br>For example, the <a target='_blank' href='https://www.nhsx.nhs.uk/ai-lab/ai-lab-programmes/skunkworks/'>NHS AI Lab Skunkworks</a> team publishes PoCs on a range of problems, such as using AI to allocate beds or predict length of stay in hospital.",
       "termCode": "poc",
       "related": [
         "trl"
       ]
     },
     {
-      "name": "TRL",
-      "description": "Technology readiness level. A <a target='_blank' href='https://en.wikipedia.org/wiki/Technology_readiness_level'>framework</a> developed by NASA to describe the different levels of maturity of a technology.<br><br>For example, a proof of concept may come under TRL level 4.<br><br>TRL levels start at 1 for a basic idea through to 9 for a fully deployed solution.",
+      "name": "Technology readiness level",
+      "acronym": "TRL",
+      "description": "A <a target='_blank' href='https://en.wikipedia.org/wiki/Technology_readiness_level'>framework</a> developed by NASA to describe the different levels of maturity of a technology.<br><br>For example, a proof of concept may come under TRL level 4.<br><br>TRL levels start at 1 for a basic idea through to 9 for a fully deployed solution.",
       "termCode": "trl",
       "related": [
         "poc"
@@ -585,6 +593,7 @@
     },
     {
       "name": "Sensitivity",
+      "alternateName": "Recall",
       "description": "The ability of a classification model to correctly identify individuals <em>with</em> a condition. This is also known as the true positive rate and recall. It is defined as the number of true positives over true positives and false negatives.<br><br>For example, an AI tool that has been developed to detect lung cancer from medical images is said to be sensitive if it correctly identifies people who have lung cancer.",
       "termCode": "sensitivity",
       "related": [
@@ -710,8 +719,9 @@
       ]
     },
     {
-      "name": "ROC",
-      "description": "Receiver Operator Characteristic. Used to create a plotted curve which demonstrates how the trade off between true positive rate and false positive rate changes as you vary the operating point of a classification model.<br><br>For an interactive demonstration of a ROC curve, visit this <a target='_blank' href='https://nhsx.github.io/covid-chest-imaging-database/experiments'>NCCID operating point experiment</a>.",
+      "name": "Receiver Operator Characteristic",
+      "acronym": "ROC",
+      "description": "Used to create a plotted curve which demonstrates how the trade off between true positive rate and false positive rate changes as you vary the operating point of a classification model.<br><br>For an interactive demonstration of a ROC curve, visit this <a target='_blank' href='https://nhsx.github.io/covid-chest-imaging-database/experiments'>NCCID operating point experiment</a>.",
       "termCode": "roc",
       "related": [
         "accuracy",
@@ -728,15 +738,16 @@
       ]
     },
     {
-      "name": "AUC",
-      "description": "Area Under the (Receiver Operator Character) Curve. A single number calculated from a ROC curve to help summarise the performance of a classification model.",
+      "name": "Area Under the (Receiver Operator Character) Curve",
+      "acronym": "AUC",
+      "description": "A single number calculated from a ROC curve to help summarise the performance of a classification model.",
       "termCode": "auc",
       "related": [
+        "roc",
         "accuracy",
         "specificity",
         "sensitivity",
         "precision",
-        "roc",
         "f1-score",
         "false-positive",
         "false-negative",
@@ -760,8 +771,9 @@
       ]
     },
     {
-      "name": "NCCID",
-      "description": "National COVID-19 Chest Imaging Database. The NCCID is a national database that supports better understanding of COVID-19 and the development of technology enabling the best care for patients hospitalised with a severe infection.",
+      "name": "National COVID-19 Chest Imaging Database",
+      "acronym": "NCCID",
+      "description": "The NCCID is a national database that supports better understanding of COVID-19 and the development of technology enabling the best care for patients hospitalised with a severe infection.",
       "termCode": "nccid",
       "related": [
         "database"
@@ -777,7 +789,8 @@
       ]
     },
     {
-      "name": "Multimodal AI",
+      "name": "Multimodal artificial intelligence",
+      "acronymn": "Multimodal AI",
       "description": "An approach to AI which incorporates multiple types of data. For example, a speech-to-text model that is typically trained on audio and text data, could include image data of lip movements taken from video recordings.<br><br>Multimodal AI can combine both numerical data such as blood pressure, heart rate, and imaging data such as a CT scan.<br><br>In healthcare, the term is also associated with specific 'modalities' of data, such as the sequences in <a target='_blank' href='https://prostatecanceruk.org/about-us/projects-and-policies/mpmri'>mpMRI</a> scanning. However, the concept of multimodality with respect to AI is more than just bringing different types of data together - it is about how very different AI models effectively interoperate - even 'merge' - to create a whole that is greater than the sum of its parts.",
       "termCode": "multimodal",
       "related": [
@@ -851,8 +864,9 @@
       ]
     },
     {
-      "name": "NLP",
-      "description": "Natural language processing. A collection of techniques which use speech and text data.<br><br>Speech-to-text systems convert verbal speech to text, such as in a smart speaker.<br>Natural language understanding systems convert text into concepts or instructions, such as your requests to play music or offer directions.<br>Text-to-speech systems convert text into verbal speech, such as responses from a smart speaker.<br>Natural language generation will create human-like text based on concepts, such as writing a report from a summary table of data.<br><br>NLP has developed significantly in recent years in part due to the availability of deep learning algorithms and transfomers.",
+      "name": "Natural language processing",
+      "acronym": "NLP",
+      "description": "A collection of techniques which use speech and text data.<br><br>Speech-to-text systems convert verbal speech to text, such as in a smart speaker.<br>Natural language understanding systems convert text into concepts or instructions, such as your requests to play music or offer directions.<br>Text-to-speech systems convert text into verbal speech, such as responses from a smart speaker.<br>Natural language generation will create human-like text based on concepts, such as writing a report from a summary table of data.<br><br>NLP has developed significantly in recent years in part due to the availability of deep learning algorithms and transfomers.",
       "termCode": "nlp",
       "related": [
         "deep-learning",

--- a/data/terms.schema.json
+++ b/data/terms.schema.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://nhsx.github.io/ai-dictionary",
     "title": "AI terms",
-    "description": "AI terms in NHSX AI Dictionary",
+    "description": "AI terms in NHS AI Lab AI Dictionary",
     "type": "object",
     "properties": {
         "terms": {
@@ -12,36 +12,44 @@
                 "description": "An AI term",
                 "type": "object",
                 "properties": {
-                    "title": {
-                        "description": "The AI term",
+                    "name": {
+                        "description": "The expanded artificial intelligence term (see acronymn)",
                         "type": "string",
                         "minLength": 1
+                    },
+                    "acronym": {
+                        "description": "The acronym form of the title, optional",
+                        "type": "string"
                     },
                     "description": {
                         "description": "The explanation of what the AI term is",
                         "type": "string",
                         "minLength": 2
                     },
-                    "slug": {
+                    "alternateName": {
+                        "description": "Synonym for this term",
+                        "type": "string"
+                    },
+                    "termCode": {
                         "description": "Short form identifier for the term, used in related terms and for URL bookmarking",
                         "type": "string",
-                        "$ref": "#/definitions/slug"
+                        "$ref": "#/definitions/termCode"
                     },
                     "related": {
                         "description": "A list of related terms",
                         "type": "array",
                         "items": {
-                            "description": "Slug for a related term",
+                            "description": "Term codes for related terms",
                             "type": "string",
-                            "$ref": "#/definitions/slug"
+                            "$ref": "#/definitions/termCode"
                         },
                         "uniqueItems": true
                     }
                 },
                 "required": [
-                    "title",
+                    "name",
                     "description",
-                    "slug",
+                    "termCode",
                     "related"
                 ]
             },
@@ -53,7 +61,7 @@
     ],
     "additionalProperties": false,
     "definitions": {
-        "slug": {
+        "termCode": {
             "description": "Unique short form identifier for a specific AI term",
             "type": "string",
             "minLength": 1

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,8 @@ const titleSort = (a, b) => {
 const titleSearch = (search, terms) => terms.filter(term =>
    term.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
    term.description.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-   term.termCode.toLowerCase().indexOf(search.toLowerCase()) > -1
+   term.termCode.toLowerCase().indexOf(search.toLowerCase()) > -1 || 
+   term.alternateName?.toLowerCase().indexOf(search.toLowerCase()) > -1
 ).sort(titleSort)
 
 export default function Home() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,12 +19,25 @@ const titleSort = (a, b) => {
 /**
  * Find search query in term titles 
  */
-const titleSearch = (search, terms) => terms.filter(term =>
-   term.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-   term.description.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-   term.termCode.toLowerCase().indexOf(search.toLowerCase()) > -1 || 
-   term.alternateName?.toLowerCase().indexOf(search.toLowerCase()) > -1
-).sort(titleSort)
+const textSearch = (search, terms) => {
+
+   // Search by acronym first 
+   const acronymSearch = terms.filter(term =>
+      term.acronym?.toLowerCase().indexOf(search.toLowerCase()) > -1
+   ).sort(titleSort)
+
+   // Search by other fields 
+   const otherSearch = terms.filter(term =>
+      term.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
+      term.description.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
+      term.termCode.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
+      term.alternateName?.toLowerCase().indexOf(search.toLowerCase()) > -1
+   ).sort(titleSort)
+
+   // Merge and remove duplicates
+   return [...new Set([...acronymSearch, ...otherSearch])]
+   
+}
 
 export default function Home() {
 
@@ -41,7 +54,7 @@ export default function Home() {
    const [searchTerm, setSearchTerm] = useState('')
    const [keyToggle, setKeyToggle] = useState(false)
    const [currentTermIndex, setCurrentTermIndex] = useState(null)
-   const filteredTerms = useMemo(() => terms?.length > 0 ? (searchTerm?.length > 0 ? titleSearch(searchTerm, terms) : [...terms].sort(titleSort)) : [], [searchTerm])
+   const filteredTerms = useMemo(() => terms?.length > 0 ? (searchTerm?.length > 0 ? textSearch(searchTerm, terms) : [...terms].sort(titleSort)) : [], [searchTerm])
    const currentTerm = useMemo(() => currentTermIndex !== null ? terms[currentTermIndex] : null, [currentTermIndex])
 
    /**

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,8 +11,8 @@ import Header from "components/Header"
  * Sort by title property 
  */
 const titleSort = (a, b) => {
-   if (a.title < b.title) return -1
-   if (b.title < a.title) return 1
+   if (a.name < b.name) return -1
+   if (b.name < a.name) return 1
    return 0
 }
 
@@ -20,9 +20,9 @@ const titleSort = (a, b) => {
  * Find search query in term titles 
  */
 const titleSearch = (search, terms) => terms.filter(term =>
-   term.title.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
+   term.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
    term.description.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-   term.slug.toLowerCase().indexOf(search.toLowerCase()) > -1
+   term.termCode.toLowerCase().indexOf(search.toLowerCase()) > -1
 ).sort(titleSort)
 
 export default function Home() {
@@ -52,7 +52,7 @@ export default function Home() {
    // On slug change
    useEffect(() => {
       if (currentTermSlug) {
-         setCurrentTermIndex(terms.findIndex(term => term.slug === currentTermSlug))
+         setCurrentTermIndex(terms.findIndex(term => term.termCode === currentTermSlug))
       }
    }, [currentTermSlug])
 
@@ -91,7 +91,7 @@ export default function Home() {
     */
    useEffect(() => {
       if (!showTerm) router.replace({ pathname: '/', query: null })
-      else if (router.query.term !== currentTerm.slug) router.replace({ pathname: '/', query: { term: currentTerm.slug } })
+      else if (router.query.term !== currentTerm.termCode) router.replace({ pathname: '/', query: { term: currentTerm.termCode } })
    }, [currentTerm, showTerm])
 
    /**
@@ -107,8 +107,8 @@ export default function Home() {
    /**
     * Select term by slug 
     */
-   const selectTermBySlug = (slug) => {
-      const matchingIndex = terms.findIndex((term) => term.slug === slug)
+   const selectTermBySlug = (termCode) => {
+      const matchingIndex = terms.findIndex((term) => term.termCode === termCode)
       if (matchingIndex >= 0) {
          setCurrentTermIndex(matchingIndex)
          setShowTerm(true)

--- a/tests/validate_json.py
+++ b/tests/validate_json.py
@@ -44,45 +44,45 @@ try:
 except:
     raise Exception("Unable to parse terms.json as valid json")
 
-# Check for unique slugs
+# Check for unique termCodes
 
-slugs = []
+termCodes = []
 for term in terms["terms"]:
-    if term["slug"] in slugs:
-        raise Exception(f"Duplicate slug found for \"{term['slug']}\"")
+    if term["termCode"] in termCodes:
+        raise Exception(f"Duplicate termCode found for \"{term['termCode']}\"")
     else:
-        slugs.append(term["slug"])
+        termCodes.append(term["termCode"])
 
-print(f"{len(slugs)} unique slug(s) in database")
+print(f"{len(termCodes)} unique termCode(s) in database")
 
-# Check for unique titles
+# Check for unique names
 
-titles = []
+names = []
 for term in terms["terms"]:
-    if term["title"] in titles:
-        raise Exception(f"Duplicate title found for \"{term['title']}\"")
+    if term["name"] in names:
+        raise Exception(f"Duplicate name found for \"{term['name']}\"")
     else:
-        titles.append(term["title"])
+        names.append(term["name"])
 
-print(f"{len(titles)} unique title(s) in database")
+print(f"{len(names)} unique name(s) in database")
 
 # Check for orphaned slugs
 
 for term in terms["terms"]:
     related = term["related"]
-    for related_slug in related:
-        if related_slug not in slugs:
-            raise Exception(f"Orphaned related slug found: {related_slug}")
-print("No orphaned slugs found")
+    for related_termCode in related:
+        if related_termCode not in termCodes:
+            raise Exception(f"Orphaned related termCode found: {related_termCode}")
+print("No orphaned termCode found")
 
 # Check for self-referencing terms
 
 for term in terms["terms"]:
     related = term["related"]
-    for related_slug in related:
-        if related_slug == term["slug"]:
-            raise Exception(f"Self-referencing slug found: {related_slug}")
-print("No self-referencing slugs found")
+    for related_termCode in related:
+        if related_termCode == term["termCode"]:
+            raise Exception(f"Self-referencing termCode found: {related_termCode}")
+print("No self-referencing terms found")
 
 # Check valid links
 


### PR DESCRIPTION
This PR updates the schema and terms:

1. To more closely follow https://schema.org/DefinedTerm:
    1. `name` not `title`
    2. `termCode` not `slug`
    3. add `alternateName`
    4. add `acronymn`

2. Updates variable names in the UI to match above, but not function names

We need to:

- [x] Have the option to show acronyms or fully expanded names, and update the UI accordingly
- [x] If showing by acronym, the first sentence of the description should be the name and vice versa
- [x] When searching, favour matches on acronym first
- [x] Enable search by `alternateName`
- [x] Include `alternateName` in the description. Perhaps second added sentence: "Also known as {alternateName}"