### PR TITLE
Bug/related term ordering

### DIFF
--- a/components/Term.js
+++ b/components/Term.js
@@ -8,7 +8,8 @@ export default function Term({ isOpen, title, description, related, onClose, onN
    /**
     * Get related terms from array
     */
-   const relatedTerms = related ? data.terms.filter(term => related.includes(term.slug)) : []
+   const relatedTerms = related?.length ? related.map(slug => data.terms.find(term => term.slug === slug)) : []
+   console.log(relatedTerms)
 
    return (
       <Transition appear show={isOpen} as={Fragment}>

--- a/components/Term.js
+++ b/components/Term.js
@@ -9,7 +9,6 @@ export default function Term({ isOpen, title, description, related, onClose, onN
     * Get related terms from array
     */
    const relatedTerms = related?.length ? related.map(slug => data.terms.find(term => term.slug === slug)) : []
-   console.log(relatedTerms)
 
    return (
       <Transition appear show={isOpen} as={Fragment}>


### PR DESCRIPTION
Fixes a bug where the related terms JSON ordering was being overwritten.
This was down to the JS filter method taking precedence and returning the order of matched terms (based off the overall term list, not the related list). 