### PR TITLE
fix ct-new-terms

### DIFF
--- a/data/terms.json
+++ b/data/terms.json
@@ -1089,7 +1089,6 @@
         "neural-network",
         "deep-learning",
         "ai",
-        "cnn",
         "computer-vision",
         "segmentation"
       ]


### PR DESCRIPTION
* Enabled automated tests on my development branch - apologies, hadn't realised they were disabled on cloning
* fix Exception: Self-referencing termCode found: cnn
* Now passes tests ✅
* Brought up to date with main 🔃